### PR TITLE
Fetch the flags from the correct data structure

### DIFF
--- a/src/inotify.lisp
+++ b/src/inotify.lisp
@@ -322,7 +322,7 @@ registration.  If HANDLE is specified EVENT is ignored."
                         flags)))
     (let ((it (gethash pathname (inotify-pathnames inotify))))
       (if it
-          (union (cdr it) rep-flags :test #'eq)
+          (union (third it) rep-flags :test #'eq)
           rep-flags))))
 
 (defun watch (inotify pathname flags &key (replace-p T))


### PR DESCRIPTION
The result if `(gethash pathname (inotify-pathnames inotify))` is `'(pathname handle flags)`.

To merge the flags with the provided ones, we need to merge with the flags stored in the hash-table.

`(cdr it)` ends up being `'(handle flags)`, which ends up with an error when the integer gets too high, otherwise ignored for small values.

(I ended up hitting this issue with a few thousands of inotify watches.)