### PR TITLE
reimplementing SANE-USER-FLAGS and other things

### DIFF
--- a/src/inotify.lisp
+++ b/src/inotify.lisp
@@ -322,7 +322,7 @@ registration.  If HANDLE is specified EVENT is ignored."
                         (cons :mask-add flags))))
     (let ((it (gethash pathname (inotify-pathnames inotify))))
       (if it
-          (union (cdr it) rep-flags :test #'eq)
+          (union (third it) rep-flags :test #'eq)
           rep-flags))))
 
 (defun watch (inotify pathname flags &key (replace-p T))

--- a/src/inotify.lisp
+++ b/src/inotify.lisp
@@ -213,11 +213,17 @@ the file descriptor is set to non-blocking I/O."
              (set-nonblocking fd T))
            (setf stream
                  ;; TODO: what about the blocking?
-                 #-(or clisp sbcl)
+                 #-(or ccl clisp sbcl)
                  (osicat::make-fd-stream
                   fd
                   :direction :input
                   :element-type '(unsigned-byte 8))
+                 #+ccl
+                 (ccl::make-fd-stream
+                  fd
+                  :direction :input
+                  :element-type '(unsigned-byte 8)
+                  :auto-close T)
                  #+clisp
                  (ext:make-stream
                   fd

--- a/src/inotify.lisp
+++ b/src/inotify.lisp
@@ -318,8 +318,8 @@ registration.  If HANDLE is specified EVENT is ignored."
   ;; merge the flags
   (let* ((flags (ensure-list flags))
          (rep-flags (if replace-p
-                        (cons :mask-add flags)
-                        flags)))
+                        flags
+                        (cons :mask-add flags))))
     (let ((it (gethash pathname (inotify-pathnames inotify))))
       (if it
           (union (cdr it) rep-flags :test #'eq)


### PR DESCRIPTION
Hi Olof-Joachim,

We noticed that replace-p actually does not work as documented.
You might want to look at this or just ignore it.

With greetings from the Engelbecken in Berlin,
Max